### PR TITLE
export values from non-assoc arrays

### DIFF
--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -86,7 +86,11 @@ class FormExtension extends \Twig_Extension
                 }
                 return '{'.implode(',', $items).'}';
             } else {
-                return '['.implode(',', $var).']';
+                $items = array();
+                foreach($var as $val) {
+                    $items[] = $this->export_for_js($val);
+                }
+                return '['.implode(',', $items).']';
             }
         }
         


### PR DESCRIPTION
This fixes js error for date_picker, datetime_picker, daterange_picker caused by unquoted strings
