### PR TITLE
[Patch] Change logic to add avocode twig form resources

### DIFF
--- a/DependencyInjection/AvocodeFormExtensionsExtension.php
+++ b/DependencyInjection/AvocodeFormExtensionsExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * Loads FormExtensions configuration
- * 
+ *
  * @author Piotr Gołębiewski <loostro@gmail.com>
  */
 class AvocodeFormExtensionsExtension extends Extension
@@ -22,24 +22,25 @@ class AvocodeFormExtensionsExtension extends Extension
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
-        
+
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
-        
+
         $container->setParameter('avocode.form.upload_manager', $config['upload_manager']);
         $container->setParameter('avocode.form.image_manipulator', $config['image_manipulator']);
-        
+        $container->setParameter('avocode.form.twig', $config['twig']);
+
         $this->loadBootstrapCollectionTypes($container);
         $this->loadDoubleListTypes($container);
         $this->loadSelect2Types($container);
     }
-    
+
     private function loadBootstrapCollectionTypes(ContainerBuilder $container)
     {
         $serviceId = 'avocode.form.extensions.type.bootstrap_collection';
-        
+
         $bootstrapCollectionTypes = array('fieldset', 'table');
-        
+
         foreach ($bootstrapCollectionTypes as $type) {
             $typeDef = new DefinitionDecorator($serviceId);
             $typeDef
@@ -50,15 +51,15 @@ class AvocodeFormExtensionsExtension extends Extension
             $container->setDefinition($serviceId.'.'.$type, $typeDef);
         }
     }
-    
+
     private function loadDoubleListTypes(ContainerBuilder $container)
     {
         $serviceId = 'avocode.form.extensions.type.double_list';
-        
+
         $doubleListTypes = array(
             'entity', 'document', 'model'
         );
-        
+
         foreach ($doubleListTypes as $type) {
             $typeDef = new DefinitionDecorator($serviceId);
             $typeDef
@@ -69,16 +70,16 @@ class AvocodeFormExtensionsExtension extends Extension
             $container->setDefinition($serviceId.'.'.$type, $typeDef);
         }
     }
-    
+
     private function loadSelect2Types(ContainerBuilder $container)
     {
         $serviceId = 'avocode.form.extensions.type.select2';
-        
+
         $select2types = array(
-            'choice', 'language', 'country', 'timezone', 
+            'choice', 'language', 'country', 'timezone',
             'locale', 'entity', 'document', 'model', 'hidden'
         );
-        
+
         foreach ($select2types as $type) {
             $typeDef = new DefinitionDecorator($serviceId);
             $typeDef

--- a/DependencyInjection/Compiler/FormCompilerPass.php
+++ b/DependencyInjection/Compiler/FormCompilerPass.php
@@ -17,24 +17,29 @@ class FormCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $resources = $container->getParameter('twig.form.resources');
+        if (($twigConfiguration = $container->getParameter('avocode.form.twig')) !== false) {
+            $resources = $container->getParameter('twig.form.resources');
+            $alreadyImported = in_array('AvocodeFormExtensionsBundle:Form:form_widgets.html.twig', $resources);
 
-        // Insert right after form_div_layout.html.twig if exists
-        if (($key = array_search('form_div_layout.html.twig', $resources)) !== false) {
-            array_splice($resources, ++$key, 0, array(
-                'AvocodeFormExtensionsBundle:Form:form_widgets.html.twig',
-                'AvocodeFormExtensionsBundle:Form:form_javascripts.html.twig',
-                'AvocodeFormExtensionsBundle:Form:form_stylesheets.html.twig'
-            ));
-        } else {
-            // Put it in first position
-            array_unshift($resources, array(
-                'AvocodeFormExtensionsBundle:Form:form_widgets.html.twig',
-                'AvocodeFormExtensionsBundle:Form:form_javascripts.html.twig',
-                'AvocodeFormExtensionsBundle:Form:form_stylesheets.html.twig'
-            ));
+            if ($twigConfiguration['use_form_resources'] && !$alreadyImported) {
+                // Insert right after form_div_layout.html.twig if exists
+                if (($key = array_search('form_div_layout.html.twig', $resources)) !== false) {
+                    array_splice($resources, ++$key, 0, array(
+                        'AvocodeFormExtensionsBundle:Form:form_widgets.html.twig',
+                        'AvocodeFormExtensionsBundle:Form:form_javascripts.html.twig',
+                        'AvocodeFormExtensionsBundle:Form:form_stylesheets.html.twig'
+                    ));
+                } else {
+                    // Put it in first position
+                    array_unshift($resources, array(
+                        'AvocodeFormExtensionsBundle:Form:form_widgets.html.twig',
+                        'AvocodeFormExtensionsBundle:Form:form_javascripts.html.twig',
+                        'AvocodeFormExtensionsBundle:Form:form_stylesheets.html.twig'
+                    ));
+                }
+
+                $container->setParameter('twig.form.resources', $resources);
+            }
         }
-
-        $container->setParameter('twig.form.resources', $resources);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * Validates and merges configuration
- * 
+ *
  * @author Piotr Gołębiewski <loostro@gmail.com>
  */
 class Configuration implements ConfigurationInterface
@@ -19,11 +19,17 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('avocode_form_extensions');
-        
+
         $rootNode
             ->children()
                 ->scalarNode('upload_manager')->defaultNull()->end()
                 ->scalarNode('image_manipulator')->defaultNull()->end()
+                ->arrayNode('twig')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('use_form_resources')->defaultTrue()->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 


### PR DESCRIPTION
Add twig form resources at the beginning of available resources (so application can override default renders provided by avocode formextensions bundle).
