### PR TITLE
Fix call of bootstrap-timepicker.min.js

### DIFF
--- a/Resources/views/javascripts_assetic_less.html.twig
+++ b/Resources/views/javascripts_assetic_less.html.twig
@@ -17,7 +17,7 @@
     <script type="text/javascript" src="{{ asset('bundles/avocodeformextensions/daterangepicker/js/daterangepicker.min.js') }}"></script>
     <script type="text/javascript" src="{{ asset('bundles/avocodeformextensions/double-list/js/double-list.min.js') }}"></script>
     <script type="text/javascript" src="{{ asset('bundles/avocodeformextensions/select2/js/select2.min.js') }}"></script>
-    <script type="text/javascript" src="{{ asset('bundles/avocodeformextensions/timepicker/js/timepicker.min.js') }}"></script>
+    <script type="text/javascript" src="{{ asset('bundles/avocodeformextensions/timepicker/js/bootstrap-timepicker.min.js') }}"></script>
 
     <!-- locale -->
     {% if app.request.locale in ['ca', 'cs', 'da', 'de', 'es', 'et', 'eu', 'fr', 'gl', 'he', 'hr', 'hu', 'is', 'it', 'ja', 'lt', 'lv', 'mk', 'nl', 'no', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sv', 'tr', 'ua', 'vi', 'zh-CN', 'zh-TW'] %}


### PR DESCRIPTION
There was a typo in the javascript_assetic_less.html.twig file, the timepicker js file was not the good one.
