### PR TITLE
Added default_time to datetime picker

### DIFF
--- a/Form/Type/DateTimePickerType.php
+++ b/Form/Type/DateTimePickerType.php
@@ -94,6 +94,7 @@ class DateTimePickerType extends AbstractType
             'minute_step'     => 15,
             'second_step'     => 15,
             'disable_focus'   => false,
+            'default_time'    => 'current',
             'disabled'        => array(),
             'attr'            => array(
                 'class' => 'input-small'


### PR DESCRIPTION
Let the default time be set on the datetime_picker component, or else you'll always get a date sent back, even if the field is nullable.
