### PR TITLE
Fix custom date format on DateTimePicker.

### DIFF
--- a/Form/Type/DateTimePickerType.php
+++ b/Form/Type/DateTimePickerType.php
@@ -89,6 +89,7 @@ class DateTimePickerType extends AbstractType
         $resolver->setDefaults(array(
             'format'          => 'yyyy-MM-dd',
             'formatSubmit'    => 'yyyy-mm-dd',
+            'calendarWeeks'   => false,
             'weekStart'       => 1,
             'startView'       => 'month',
             'minViewMode'     => 'days',


### PR DESCRIPTION
Custom date format was not working properly on datetime_picker due to a missing option 'formatSubmit' on the $dateOptions array.

EDIT: Added missing default options 'todayButton', 'todayHighlight', 'clearButton' and specially 'language' (because it was preventing the translation of the calendar widget) on DateTimePickerType. These are options already available on DatePickerType.
