### PR TITLE
add order of registerBundles to make 'options' of HelpMessageExtension work

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ public function registerBundles()
 }
 ```
 
+You have to register AvocodeFormExtensionsBundle() before a potential registering of AdmingeneratorGeneratorBundle().
+
 To make `avocode/form-extensions-bundle` forms work, you need to edit your base 
 template, and include static and dynamic stylesheets and javascripts. 
 


### PR DESCRIPTION
I had to put the form-extensions-bundle right before the admingeneratorgenerator-bundle to make the rendering of 'help' work with the twig function form_row (using HelpMessageExtension).

This took me round about 4 hours.

``` php

        $bundles[] = new Avocode\FormExtensionsBundle\AvocodeFormExtensionsBundle();
        $bundles[] = new Admingenerator\GeneratorBundle\AdmingeneratorGeneratorBundle();
```

see also discussion in: https://github.com/avocode/FormExtensions/pull/9
