### PR TITLE
Enable usage of bootstrap datepicker() event 'changeDate'...

### DIFF
--- a/Form/Type/DatePickerType.php
+++ b/Form/Type/DatePickerType.php
@@ -81,6 +81,7 @@ class DatePickerType extends AbstractType
                                      : $options['todayButton'],
                 'todayHighlight'  => $options['todayHighlight'],
                 'clearButton'     => $options['clearButton'],
+                'changeDateEvent' => $options['changeDateEvent'],
                 'language'        => !$options['language']
                                      ? $this->getLocale()
                                      : $options['language'],
@@ -105,6 +106,7 @@ class DatePickerType extends AbstractType
             'todayButton'     => false,
             'todayHighlight'  => false,
             'clearButton'     => false,
+            'changeDateEvent' => false,
             'language'        => false,
             'attr'            => array(
                 'class' => 'input-small'
@@ -119,6 +121,7 @@ class DatePickerType extends AbstractType
             'autoclose'       => array('bool'),
             'todayHighlight'  => array('bool'),
             'clearButton'     => array('bool'),
+            'changeDateEvent' => array('bool', 'string'),
         ));
 
         $resolver->setAllowedValues(array(

--- a/Resources/views/Form/form_javascripts.html.twig
+++ b/Resources/views/Form/form_javascripts.html.twig
@@ -174,6 +174,11 @@
             startDate:            new Date({{ startDate|e4js }}),
             endDate:              new Date({{ endDate|e4js }}),
         });
+    {% if changeDateEvent %}
+        $field.datepicker().on('changeDate', function(ev){
+            {{ changeDateEvent }}
+        });
+    {% endif %}
     {% endblock afe_date_picker_afe_javascript_prototype %}
     });
 </script>
@@ -306,8 +311,8 @@
             defaultValue: $field.val(),
             theme: 'bootstrap',
             change: function(hex, opacity) {
-            	var changeEvent = $.Event('colored');
-            	$field.trigger(changeEvent, [ this, hex, opacity ]);
+                var changeEvent = $.Event('colored');
+                $field.trigger(changeEvent, [ this, hex, opacity ]);
             }
         }, {{ configs|e4js|raw }});
 


### PR DESCRIPTION
... on DatePickerType by passing an option on generator YAML file.

The idea behind this is to be able to pass on the generator.yml file something like this: 

``` yaml
addFormOptions: 
    changeDateEvent: alert('from generator');
```
