### PR TITLE
Try to correct #74

### DIFF
--- a/Resources/views/Form/form_javascripts.html.twig
+++ b/Resources/views/Form/form_javascripts.html.twig
@@ -3,9 +3,18 @@
     {% for child in form %}
         {{ afe_form_javascript(child) }}
     {% endfor %}
-    {% block form_afe_javascript_prototype %}{% endblock form_afe_javascript_prototype %}
 {% endspaceless %}
 {% endblock form_afe_javascript %}
+
+{% block form_afe_javascript_prototype %}
+{% spaceless %}
+    {% for child in form %}
+        parent.push('{{ child.vars.name }}');
+        $field = $('#' + id + '_' + parent.join('_'));
+        {{ afe_form_javascript(child, true) }}
+        parent.pop();                                                                                                                                            {% endfor %}
+{% endspaceless %}
+{% endblock form_afe_javascript_prototype %}
 
 {% block field_afe_javascript "" %}
 
@@ -26,11 +35,14 @@
             confirm_batch:  {{ 'afe_bootstrap_collection.confirm.batchDelete'|trans({}, 'AvocodeFormExtensions')|e4js }}
         },
         javascript: function(id) {
+        parent = [];
         {% if prototype is defined %}
             {% if prototype.vars.compound %}
                 {% for child in prototype %}
-                    $field = $('#' + id + '_{{ child.vars.name }}');
+                    parent.push('{{ child.vars.name }}');
+                    $field = $('#' + id + '_' + parent.join('_'));
                     {{ afe_form_javascript(child, true) }}
+                    parent.pop();
                 {% endfor %}
             {% else %}
                 $field = $('#' + id);


### PR DESCRIPTION
As I've explained in my last comment in https://github.com/avocode/FormExtensions/issues/74
I've added a parent javascript variable to keep the correct name as the direct parent is not sufficiant. I did not find an alternate/simpliest way to do that but it works well for me as in this PR.

I've also added a correction for single upload $field that was incorrect.
