### PR TITLE
Fixed empty file validation at form edit.

### DIFF
--- a/Form/EventListener/SingleUploadSubscriber.php
+++ b/Form/EventListener/SingleUploadSubscriber.php
@@ -120,7 +120,7 @@ class SingleUploadSubscriber implements EventSubscriberInterface
         if (count($this->configs) > 0) {
             $form = $event->getForm();
             $data = $event->getData();
-            
+
             if (!$form->isValid()) {
                 foreach ($this->configs as $field => $config) {
                     if ($config['nameable'] && array_key_exists('original_name', $config)) {


### PR DESCRIPTION
Added the file back into the form data (lost onbind)  for NotNull validation.

If I want to make a file mandatory:

```
    /**
     * @Assert\NotNull
     * @Assert\File(
     *     mimeTypes={"image/png", "image/jpeg", "image/pjpeg", "image/gif"}
     * )
     * @Vich\UploadableField(mapping="page_item", fileNameProperty="imagePath")
     */
    protected $image;
```

It works as expected when making a new object but it fails on edit because, as the file is not uploaded again, the file property is empty at validation time.

That's why I added the file back in the form's data if it's not being deleted or if it's not being changed (if changed the file will be on the newly binded data).
