### PR TITLE
Bugfix if own subtype of afe_single_upload

### DIFF
--- a/Form/EventListener/SingleUploadSubscriber.php
+++ b/Form/EventListener/SingleUploadSubscriber.php
@@ -31,7 +31,7 @@ class SingleUploadSubscriber implements EventSubscriberInterface
         $post = $event->getData();
 
         foreach ($form->all() as $child) {
-            if ($child->getConfig()->getType()->getName() === 'afe_single_upload') {
+            if ($this->isFieldSingleUpload($child->getConfig()->getType())) {
                 $childPost = $post[$child->getName()];
                 $options = $child->getConfig()->getOptions();
 
@@ -117,5 +117,13 @@ class SingleUploadSubscriber implements EventSubscriberInterface
                 $event->setData($data);
             }
         }
+    }
+    
+    private function isFieldSingleUpload(ResolvedFormTypeInterface $formTypeInterface = null)
+    {
+        if($formTypeInterface == null) return false;
+        if($formTypeInterface->getName() == 'afe_single_upload') return true;
+
+        return $this->isFieldSingleUpload($formTypeInterface->getParent());
     }
 }


### PR DESCRIPTION
Fixes a bug when creating an own form type which has afe_single_upload as a parent.

When creating a form type with afe_single_upload as parent the file on the entity is not set correctly. Instead it is set to array([file] => [UploadedFile]).
This happens because the SingleUploadSubscriber only checks the actual form field onto it's type, but not the parents. So if you extend the afe_single_upload its behavior changes because of that.

The fix just recurses over all parents and checks if the form extends from afe_single_upload.
