### PR TITLE
Fixed null pointer error

### DIFF
--- a/Form/EventListener/SingleUploadSubscriber.php
+++ b/Form/EventListener/SingleUploadSubscriber.php
@@ -33,8 +33,14 @@ class SingleUploadSubscriber implements EventSubscriberInterface
     {
         $form = $event->getForm();
         $obj = $event->getData();
+        
+        //can be null if prototype in collection
+        if($obj == null) {
+            return;
+        }
+        
         foreach ($form->all() as $child) {
-            if ($child->getConfig()->getType()->getName() === 'afe_single_upload') {
+            if ($this->isFieldSingleUpload($child->getConfig()->getType())) {
                 $name = $child->getName();
                 $getterName = 'get'.ucfirst($name);
                 $this->files[$name] = $obj->$getterName();


### PR DESCRIPTION
Fixes an error when using the form_upload in a collection with prototypes, as the prototype object is null.

Also fixed the check in foreach to also check the form type parents.
