### PR TITLE
Only reset the image, not the complete form

### DIFF
--- a/Resources/views/Form/SingleUpload/controls.html.twig
+++ b/Resources/views/Form/SingleUpload/controls.html.twig
@@ -1,6 +1,6 @@
 <div class="singleupload-controls-wrapper">
     <div class="btn-wrapper">
-        <button type="reset" class="btn btn-warning cancel" style="display: none;">
+        <button type="button" class="btn btn-warning cancel" style="display: none;">
             <i class="icon-ban-circle icon-white"></i>
             <span> {{ 'afe_single_upload.button.cancel'|trans({}, 'AvocodeFormExtensions') }}</span>
         </button>


### PR DESCRIPTION
The current code resets the complete form whenever the reset button is in the single upload widget. As the button only appears when the file is changed, I classify it as unwanted behaviour to reset the complete form when you only want to cancel the file change. To cancel the whole form you need to place a reset button at the bottom (or top, or whatever). 

Simply removing the button property will result in an automatic submit (I'm not sure why), but just changing it to the type button fixes the problem.
